### PR TITLE
Update to reflect release of v0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pytest-astropy" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 {% set git_url = "https://github.com/astropy/pytest-astropy" %}
-{% set sha256 = "0e8a20f4704fad19cb5d83b99a674069173099701c3f490ac7213e60c42c8f62" %}
+{% set sha256 = "8eacabc025b22459bd1db7313ba8e4236918b46cba241e49b2245c8ec69a267b" %}
 
 package:
   name: {{ name|lower }}
@@ -23,14 +23,14 @@ requirements:
     - pip
     - pytest >=3.1
     - pytest-openfiles >=0.3
-    - pytest-remotedata >=0.2.1
+    - pytest-remotedata >=0.3.0
     - pytest-doctestplus >=0.1.3
     - pytest-arraydiff >=0.1
   run:
     - python
     - pytest >=3.1
     - pytest-openfiles >=0.3
-    - pytest-remotedata >=0.2.1
+    - pytest-remotedata >=0.3.0
     - pytest-doctestplus >=0.1.3
     - pytest-arraydiff >=0.1
 


### PR DESCRIPTION
This will require https://github.com/conda-forge/pytest-remotedata-feedstock/pull/3 to be merged in order for tests to pass.